### PR TITLE
A few modifications to github-trending before merging

### DIFF
--- a/scripts/github-trending.js
+++ b/scripts/github-trending.js
@@ -25,10 +25,10 @@ function extractRepositories(error, response, body, msg) {
 
     $('h3').each(function(i, elem) {
       var link = $(this).children('a').attr("href");
-      results.push(link);
+      results.push(link.substring(1));
     });
 
-    msg.send(results.join(' - '));
+    msg.send(results.join(', '));
   }
 }
 

--- a/scripts/github-trending.js
+++ b/scripts/github-trending.js
@@ -17,40 +17,33 @@
 var cheerio = require('cheerio');
 var request = require('request')
 
+function extractRepositories(error, response, body, msg) {
+  if (!error && response.statusCode == 200) {
+    $ = cheerio.load(body);
+
+    var results = [];
+
+    $('h3').each(function(i, elem) {
+      var link = $(this).children('a').attr("href");
+      results.push(link);
+    });
+
+    msg.send(results.join(' - '));
+  }
+}
+
 module.exports = function(robot) {
 
   robot.respond(/trending$/i, function(msg){
-    request('https://github.com/trending', function(error, response, body){
-      if (!error && response.statusCode == 200) {
-        $ = cheerio.load(body);
-
-        var results = [];
-
-        $('h3').each(function(i, elem) {
-          var link = $(this).children('a').attr("href");
-          results.push(link);
-        });
-
-        msg.send(results.join(' - '));
-      }
+    request('https://github.com/trending', function(error, response, body) {
+      extractRepositories(error, response, body, msg);
     });
   });
 
   robot.respond(/trending-(.*)$/i, function(msg){
     var language = msg.match[1];
-    request('https://github.com/trending/'+language, function(error, response, body){
-      if (!error && response.statusCode == 200) {
-        $ = cheerio.load(body);
-
-        var results = [];
-
-        $('h3').each(function(i, elem) {
-          var link = $(this).children('a').attr("href");
-          results.push(link);
-        });
-
-        msg.send(results.join(' - '));
-      }
+    request('https://github.com/trending/'+language, function(error, response, body) {
+      extractRepositories(error, response, body, msg);
     });
   });
 

--- a/tests/github-trending.coffee
+++ b/tests/github-trending.coffee
@@ -19,7 +19,7 @@ describe 'github-trending', ->
 
     it 'gets the trending projects', ->
       expect(@room.messages[0]).to.eql ['john', "hubot trending"]
-      expect(@room.messages[1]).to.match /((\/.+\/.+) - ){9}(\/.+\/.+)/
+      expect(@room.messages[1]).to.match /((.+\/.+), ){9}(.+\/.+)/
 
   context "user asks for the trending repositories in python language", ->
     beforeEach ->
@@ -29,7 +29,7 @@ describe 'github-trending', ->
 
     it 'gets the python trending projects', ->
       expect(@room.messages[0]).to.eql ['john', "hubot trending-python"]
-      expect(@room.messages[1]).to.match /((\/.+\/.+) - ){9}(\/.+\/.+)/
+      expect(@room.messages[1]).to.match /((.+\/.+), ){9}(.+\/.+)/
 
   context "user asks for informations on a project", ->
     beforeEach ->

--- a/tests/github-trending.coffee
+++ b/tests/github-trending.coffee
@@ -16,10 +16,8 @@ describe 'github-trending', ->
         yield new Promise.delay(500)
 
     it 'gets the trending projects', ->
-      expect(@room.messages).to.eql [
-        ['john', "hubot trending"]
-        ['hubot', "/dthree/cash - /FreeCodeCamp/FreeCodeCamp - /facebook/draft-js - /santinic/how2 - /copy/v86 - /ryanflorence/react-project - /ImagicalMine/ImagicalMine - /VPenkov/okayNav - /IBM-Swift/Kitura - /allenwong/30DaysofSwift - /dustturtle/RealReachability - /dthree/vorpal - /ampproject/amphtml - /legomushroom/mojs - /callmecavs/bricks.js - /xiepeijie/SwipeCardView - /gabrielrcouto/php-terminal-gameboy-emulator - /codrops/Animocons - /substance/substance - /Freelander/Android_Data - /Ramotion/circle-menu - /Zepo/MLeaksFinder - /veniversum/git-visualizer - /AllThingsSmitty/css-protips - /RFStorm/mousejack"]
-      ]
+      expect(@room.messages[0]).to.eql ['john', "hubot trending"]
+      expect(@room.messages[1]).to.match /((\/.+\/.+) - ){9}(\/.+\/.+)/
 
   context "user asks for the trending repositories in python language", ->
     beforeEach ->
@@ -28,10 +26,8 @@ describe 'github-trending', ->
         yield new Promise.delay(500)
 
     it 'gets the python trending projects', ->
-      expect(@room.messages).to.eql [
-        ['john', "hubot trending-python"]
-        ['hubot', "/deepgram/sidomo - /snipsco/ntm-lasagne - /Zephrys/monica - /zero-db/zerodb - /timothycrosley/hug - /gleitz/howdoi - /ansible/ansible - /NathanEpstein/Dora - /mitsuhiko/flask - /letsencrypt/letsencrypt - /fchollet/keras - /rg3/youtube-dl - /soimort/you-get - /django/django - /openstack/bandit - /vinta/awesome-python - /XX-net/XX-Net - /tariqdaouda/pyGeno - /jflesch/paperwork - /donnemartin/data-science-ipython-notebooks - /p-e-w/maybe - /scikit-learn/scikit-learn - /kennethreitz/requests - /scrapy/scrapy - /jkbrzt/httpie"]
-      ]
+      expect(@room.messages[0]).to.eql ['john', "hubot trending-python"]
+      expect(@room.messages[1]).to.match /((\/.+\/.+) - ){9}(\/.+\/.+)/
 
   context "user asks for informations on a project", ->
     beforeEach ->

--- a/tests/github-trending.coffee
+++ b/tests/github-trending.coffee
@@ -6,6 +6,8 @@ co = require('co')
 expect = require('chai').expect
 
 describe 'github-trending', ->
+  this.timeout(5000)
+
   beforeEach ->
     @room = helper.createRoom(httpd: false)
 
@@ -13,7 +15,7 @@ describe 'github-trending', ->
     beforeEach ->
       co =>
         yield @room.user.say 'john', "hubot trending"
-        yield new Promise.delay(500)
+        yield new Promise.delay(2000)
 
     it 'gets the trending projects', ->
       expect(@room.messages[0]).to.eql ['john', "hubot trending"]
@@ -23,7 +25,7 @@ describe 'github-trending', ->
     beforeEach ->
       co =>
         yield @room.user.say 'john', "hubot trending-python"
-        yield new Promise.delay(500)
+        yield new Promise.delay(2000)
 
     it 'gets the python trending projects', ->
       expect(@room.messages[0]).to.eql ['john', "hubot trending-python"]
@@ -33,7 +35,7 @@ describe 'github-trending', ->
     beforeEach ->
       co =>
         yield @room.user.say 'john', "hubot trending /santinic/how2"
-        yield new Promise.delay(500)
+        yield new Promise.delay(2000)
 
     it 'gets the python trending projects', ->
       expect(@room.messages).to.eql [
@@ -45,7 +47,7 @@ describe 'github-trending', ->
     beforeEach ->
       co =>
         yield @room.user.say 'john', "hubot trending /bad_user/bad_project"
-        yield new Promise.delay(500)
+        yield new Promise.delay(2000)
 
     it 'gets the python trending projects', ->
       expect(@room.messages).to.eql [


### PR DESCRIPTION
This pull request changes a few things to `github-trending`, before merging pchaigno/hewbot#14:
- Use a regex to check output in tests.
- Increase timeout values to ensure tests pass.
- A bit of code refactoring in `github-trending.js`.
- I changed the output format to `user1/repo1, user2/repo2, ...` instead of `/user1/repo1 - /user2/repo2, ...`. It's the last commit so I can easily revert if you prefer.